### PR TITLE
feat(index): let stylelint-scss do its job with the at-rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,6 @@ module.exports = {
         "scss/at-mixin-no-argumentless-call-parentheses": true,
         "scss/selector-no-redundant-nesting-selector": true,
         "at-rule-blacklist": ["extend"],
-        "at-rule-no-unknown": [
-            true,
-            { ignoreAtRules: ["extend", "at-root", "debug", "warn", "error", "if", "else", "for", "each", "while", "mixin", "include", "function", "return"] },
-        ],
         "at-rule-no-vendor-prefix": true,
         "color-named": "never",
         "color-hex-case": "upper",

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
         "at-rule-blacklist": ["extend"],
         "at-rule-no-unknown": [
             true,
-            { ignoreAtRules: [ "extend", "at-root", "debug", "warn", "error", "if", "else", "for", "each", "while", "mixin", "include", "function", "return" ] },
+            { ignoreAtRules: ["extend", "at-root", "debug", "warn", "error", "if", "else", "for", "each", "while", "mixin", "include", "function", "return"] },
         ],
         "at-rule-no-vendor-prefix": true,
         "color-named": "never",

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
         "at-rule-blacklist": ["extend"],
         "at-rule-no-unknown": [
             true,
-            { ignoreAtRules: ["each", "else", "for", "if", "include", "mixin"] },
+            { ignoreAtRules: [ "extend", "at-root", "debug", "warn", "error", "if", "else", "for", "each", "while", "mixin", "include", "function", "return" ] },
         ],
         "at-rule-no-vendor-prefix": true,
         "color-named": "never",


### PR DESCRIPTION
By default, Stylelint only identifies CSS `at-rules` as valid. These include `@import`, `@media`, etc. But SCSS `at-rules`, such as `@function` and `@return` are not classified as valid `at-rules`. While we touched on a few of these in the ignore rules, we missed many others that were causing linting issues later on. This fixes those.

[More reading](https://github.com/stylelint/stylelint/issues/1612#issuecomment-231365164) on `at-rule` directives and how Stylelint handles these: